### PR TITLE
Add structured logger (and traceID to logging)

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/prometheus/prompb"
@@ -86,7 +85,7 @@ func NewConfiguredLogger(format string, logLevel string) (log.Logger, error) {
 	case "json":
 		logger = log.NewJSONLogger(os.Stdout)
 	default:
-		return nil, errors.Errorf("%s is not a valid log format", format)
+		return nil, fmt.Errorf("%s is not a valid log format", format)
 	}
 
 	var filterOption level.Option
@@ -100,7 +99,7 @@ func NewConfiguredLogger(format string, logLevel string) (log.Logger, error) {
 	case "error":
 		filterOption = level.AllowError()
 	default:
-		return nil, errors.Errorf("%s is not a valid log level", logLevel)
+		return nil, fmt.Errorf("%s is not a valid log level", logLevel)
 	}
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(5))
 	logger = level.NewFilter(logger, filterOption)

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func initTracer(logger log.Logger) func() {
 	return flush
 }
 
-func InitConfiguredLogger(format string, logLevel string) (log.Logger, error) {
+func NewConfiguredLogger(format string, logLevel string) (log.Logger, error) {
 	var logger log.Logger
 	switch format {
 	case "logfmt":
@@ -111,7 +111,7 @@ func main() {
 	fmt.Println("info: starting up thanos-remote-read...")
 	flag.Parse()
 
-	logger, err := InitConfiguredLogger(*flagLogFormat, *flagLogLevel)
+	logger, err := NewConfiguredLogger(*flagLogFormat, *flagLogLevel)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not initialize logger: %s", err)
 		os.Exit(1)

--- a/main_test.go
+++ b/main_test.go
@@ -58,6 +58,8 @@ func TestMain(m *testing.M) {
 	var logOutput bytes.Buffer
 	log.SetOutput(&logOutput)
 
+	logger, err := NewConfiguredLogger("logfmt", "error")
+
 	ctx := context.Background()
 	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
 	if err != nil {
@@ -65,7 +67,7 @@ func TestMain(m *testing.M) {
 	}
 
 	defer conn.Close()
-	setup(conn)
+	setup(conn, logger)
 
 	status := m.Run()
 	if status != 0 {


### PR DESCRIPTION
This commit swaps stdlib log for go-kit structured logger and defaults to logfmt
format for logging. In addition, it adds traceID to logs to make it play nicely
and integrate better between log and tracing systems.