### PR TITLE
enable dependabot for github actions and go packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
The goal of this PR is to enable DependaBot to open PRs for keeping GitHub actions and go modules up-to-date

Resolves: https://github.com/G-Research/oss-portfolio-maturity/issues/412