### PR TITLE
CI: Fix warnings & deprecation messages in the workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, sendToGitHub/*, 637-thanos-remote-read-github-deprecation--warnings ]
+    branches: [ master, sendToGitHub/* ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, sendToGitHub/* ]
+    branches: [ master, sendToGitHub/*, 637-thanos-remote-read-github-deprecation--warnings ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,7 +5,6 @@ on:
       - master
       # For testing docker building if needed
       - build/*
-      - 637-thanos-remote-read-github-deprecation--warnings
 
     tags:
       - v*
@@ -24,13 +23,13 @@ jobs:
         run: docker build -t image .
 
       - name: Log into registry
-        # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Push image
-        # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         run: |
           GITHUB_ID="docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME"
           DOCKERHUB_ID="gresearchdev/$IMAGE_NAME"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -5,6 +5,7 @@ on:
       - master
       # For testing docker building if needed
       - build/*
+      - 637-thanos-remote-read-github-deprecation--warnings
 
     tags:
       - v*
@@ -23,13 +24,13 @@ jobs:
         run: docker build -t image .
 
       - name: Log into registry
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
           echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
       - name: Push image
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        # if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         run: |
           GITHUB_ID="docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME"
           DOCKERHUB_ID="gresearchdev/$IMAGE_NAME"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Build image
         run: docker build -t image .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
#### What type of PR is this?

CI: Resolve deprecation & warning messages in workflows 
Enable DependaBot for GitHub actions

#### What this PR does / why we need it:

Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). - more info in the [post](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/) 

- Bump the steps where deprecation/warnings are shown in the job 


#### Which issue(s) this PR fixes:

Resolves: https://github.com/G-Research/gr-oss/issues/637

------------

## Testing results


### PASSED 🟢 

**Test**
 - https://github.com/gr-oss-devops/thanos-remote-read/actions/runs/8536410946/job/23384865499?pr=1
__NOTE__ this workflow also failed on [upstream](https://github.com/G-Research/thanos-remote-read/actions/runs/8827111586) due to wrong format 

**Docker** 
 - https://github.com/gr-oss-devops/thanos-remote-read/actions/runs/8878080575/job/24372994939
__NOTE__ needed mocking in order to test

**CodeQL** 
 - https://github.com/gr-oss-devops/thanos-remote-read/actions/runs/8877615491